### PR TITLE
adopt jsonplaceholder remote call api changes

### DIFF
--- a/app/src/main/java/com/example/offline/domain/services/networking/RemoteCommentEndpoint.java
+++ b/app/src/main/java/com/example/offline/domain/services/networking/RemoteCommentEndpoint.java
@@ -8,6 +8,6 @@ import retrofit2.http.POST;
 
 interface RemoteCommentEndpoint {
 
-    @POST("comments")
+    @POST("/posts")
     Call<Comment> addComment(@Body Comment comment);
 }

--- a/app/src/main/java/com/example/offline/model/Comment.java
+++ b/app/src/main/java/com/example/offline/model/Comment.java
@@ -5,7 +5,7 @@ import android.arch.persistence.room.Entity;
 import android.arch.persistence.room.Ignore;
 import android.arch.persistence.room.PrimaryKey;
 
-import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
 
@@ -15,19 +15,16 @@ import java.io.Serializable;
 @Entity
 public class Comment implements Serializable {
 
-    @Expose
     @PrimaryKey(autoGenerate = true)
     private long id;
 
-    @Expose
     @ColumnInfo(name = "photo_id")
     private long photoId;
 
-    @Expose
+    @SerializedName("body")
     @ColumnInfo(name = "comment_text")
     private String commentText;
 
-    @Expose
     @ColumnInfo(name = "timestamp")
     private long timestamp;
 


### PR DESCRIPTION
http://jsonplaceholder.typicode.com/ no longer supports POST for random Pojos. This PR adjusts remote calls to http://jsonplaceholder.typicode.com/ so that comments are POSTed as **posts**

Fixes https://github.com/jshvarts/OfflineSampleApp/issues/6